### PR TITLE
fixes for installation and dependency from module pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,3 +15,6 @@ endforeach()
 
 add_subdirectory(pass)
 add_subdirectory(runtime)
+
+install(DIRECTORY "pass/include" DESTINATION .)
+

--- a/pass/CMakeLists.txt
+++ b/pass/CMakeLists.txt
@@ -26,3 +26,6 @@ llvm_map_components_to_libnames(llvm_libs support core passes)
 target_include_directories(dswp PUBLIC "include")
 
 target_link_libraries(dswp ${llvm_libs})
+
+install(TARGETS dswp DESTINATION lib)
+

--- a/pass/include/DecoupleLoops.h
+++ b/pass/include/DecoupleLoops.h
@@ -24,11 +24,12 @@ private:
   map<const Function *, LoopInfo *> LI;
   map<const Loop *, set<const set<const Instruction *> *>> LoopToIterScc;
   map<const Loop *, set<const set<const Instruction *> *>> LoopToWorkScc;
+  PDGSCCGraphPass *PSGP;
 
 public:
   static char ID;
 
-  DecoupleLoopsPass() : FunctionPass(ID) {}
+  DecoupleLoopsPass() : FunctionPass(ID), PSGP(nullptr) {}
 
   bool runOnFunction(Function &F) override;
 

--- a/pass/include/DecoupleLoops.h
+++ b/pass/include/DecoupleLoops.h
@@ -50,9 +50,11 @@ public:
   }
 
   // Is Inst a work instruction in the loop L?
+  bool isWork(const Instruction &Inst, const Loop *L) const;
   bool isWork(const Instruction &Inst, const Loop *L);
 
   // Is Inst an iter instruction in the loop L?
+  bool isIter(const Instruction &Inst, const Loop *L) const;
   bool isIter(const Instruction &Inst, const Loop *L);
 
   // Does loop L have work instructions?

--- a/pass/src/DecoupleLoops.cpp
+++ b/pass/src/DecoupleLoops.cpp
@@ -110,13 +110,25 @@ bool DecoupleLoopsPass::runOnFunction(Function &F) {
   return false;
 }
 
+bool DecoupleLoopsPass::isWork(const Instruction &Inst, const Loop *L) const {
+  const auto &LWSCC = LoopToWorkScc.find(L);
+  if (LWSCC == LoopToWorkScc.end()) return false;
+  return (LWSCC->second).find(PSGP->getSCC(&Inst)) != (LWSCC->second).end();
+}
+
 bool DecoupleLoopsPass::isWork(const Instruction &Inst, const Loop *L) {
-  return LoopToWorkScc[L].find(PSGP->getSCC(&Inst)) !=
-      LoopToWorkScc[L].end();
+  return static_cast<const DecoupleLoopsPass *>(this)->isWork(Inst, L);
+}
+
+bool DecoupleLoopsPass::isIter(const Instruction &Inst, const Loop *L) const {
+  const auto&LISCC = LoopToIterScc.find(L);
+  if (LISCC == LoopToIterScc.end()) return false;
+  return (LISCC->second).find(PSGP->getSCC(&Inst)) != (LISCC->second).end();
 }
 
 bool DecoupleLoopsPass::isIter(const Instruction &Inst, const Loop *L) {
-  return LoopToIterScc[L].find(PSGP->getSCC(&Inst)) !=
-      LoopToIterScc[L].end();
+  return static_cast<const DecoupleLoopsPass *>(this)->isIter(Inst, L);
 }
+
 }
+

--- a/pass/src/DecoupleLoops.cpp
+++ b/pass/src/DecoupleLoops.cpp
@@ -48,8 +48,8 @@ RegisterPass<DecoupleLoopsPass> DecoupleLoopsRegister(
 bool DecoupleLoopsPass::runOnFunction(Function &F) {
   typedef const set<const Instruction *> *SccConstPtr;
 
-  const PDGSCCGraphPass &PSGP = Pass::getAnalysis<PDGSCCGraphPass>();
-  const DependenceGraph<set<const Instruction *>> &PSG = PSGP.getPSG();
+  PSGP = &(Pass::getAnalysis<PDGSCCGraphPass>());
+  const DependenceGraph<set<const Instruction *>> &PSG = PSGP->getPSG();
 
   DominatorTree DT;
   DT.recalculate(F);
@@ -74,7 +74,7 @@ bool DecoupleLoopsPass::runOnFunction(Function &F) {
          BI != BE; ++BI) {
       BasicBlock *BB = *BI;
       for (Instruction &Inst : *BB) {
-        SccToLoop[PSGP.getSCC(&Inst)] = L;
+        SccToLoop[PSGP->getSCC(&Inst)] = L;
       }
     }
   }
@@ -111,14 +111,12 @@ bool DecoupleLoopsPass::runOnFunction(Function &F) {
 }
 
 bool DecoupleLoopsPass::isWork(const Instruction &Inst, const Loop *L) {
-  const PDGSCCGraphPass &PSGP = Pass::getAnalysis<PDGSCCGraphPass>();
-  return LoopToWorkScc[L].find(PSGP.getSCC(&Inst)) !=
+  return LoopToWorkScc[L].find(PSGP->getSCC(&Inst)) !=
       LoopToWorkScc[L].end();
 }
 
 bool DecoupleLoopsPass::isIter(const Instruction &Inst, const Loop *L) {
-  const PDGSCCGraphPass &PSGP = Pass::getAnalysis<PDGSCCGraphPass>();
-  return LoopToIterScc[L].find(PSGP.getSCC(&Inst)) !=
+  return LoopToIterScc[L].find(PSGP->getSCC(&Inst)) !=
       LoopToIterScc[L].end();
 }
 }

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -9,7 +9,7 @@ PROJECT_INSTALL_REL_DIR="install"
 
 echo "project root dir: ${PROJECT_ROOT}"
 echo "project relative build dir: ${PROJECT_BUILD_REL_DIR}"
-echo "project relative install dir: ${PROJECT_INSTALL_REL_DIR}"
+echo "project relative install dir: ${PROJECT_INSTALL_DIR}"
 
 if [ ! -d "${PROJECT_BUILD_REL_DIR}" ]; then
   echo "creating build directory"
@@ -27,7 +27,7 @@ if [ ! -d "${PROJECT_BUILD_REL_DIR}" ]; then
 #- CMAKE_EXPORT_COMPILE_COMMANDS exports the project's compilation db
 #  (e.g. use with YCM)
 
-LINKER_FLAGS="-Wl,-L$(llvm-config --libdir) -lc++ -lc++abi" 
+LINKER_FLAGS="-Wl,-rpath-link=$(llvm-config --libdir) -lc++ -lc++abi" 
 
   CC=clang CXX=clang++ \
   cmake \
@@ -39,7 +39,8 @@ LINKER_FLAGS="-Wl,-L$(llvm-config --libdir) -lc++ -lc++abi"
     -DCMAKE_EXE_LINKER_FLAGS="${LINKER_FLAGS}" \
     -DCMAKE_SHARED_LINKER_FLAGS="${LINKER_FLAGS}" \
     -DCMAKE_MODULE_LINKER_FLAGS="${LINKER_FLAGS}" \
-    -DCMAKE_INSTALL_PREFIX=../"${PROJECT_INSTALL_REL_DIR}" \
+    -DCMAKE_INSTALL_RPATH="$(llvm-config --libdir)" \
+    -DCMAKE_INSTALL_PREFIX="${PROJECT_INSTALL_DIR}" \
     "${PROJECT_ROOT}"
 
   popd # ${PROJECT_BUILD_REL_DIR}


### PR DESCRIPTION
- change to allow installation of targets in order to create a clean and separate directory where dependent targets can base their builds/installations on

- when the pass is run by a pass of a higher IR construct (e.g. from a Module pass),
the analysis results from further dependent passes (in our case PDGSCCGraphPass) need to gathered and cached when that pass is executed (during its runOn method).